### PR TITLE
Virtualized MAC and PCI vendor detection

### DIFF
--- a/SafeExamBrowser.SystemComponents.Contracts/ISystemInfo.cs
+++ b/SafeExamBrowser.SystemComponents.Contracts/ISystemInfo.cs
@@ -44,13 +44,13 @@ namespace SafeExamBrowser.SystemComponents.Contracts
 		string OperatingSystemInfo { get; }
 
 		/// <summary>
-		/// The MAC Addres of the network addapter
+		/// The MAC address of the network adapter
 		/// </summary>
 		string MacAddress { get; }
 
 		/// <summary>
 		/// Provides the DeviceID information of the user's Plug and Play devices 
 		/// </summary>
-		string[] DeviceId { get; }
+		string[] PlugAndPlayDeviceIds { get; }
 	}
 }

--- a/SafeExamBrowser.SystemComponents.Contracts/ISystemInfo.cs
+++ b/SafeExamBrowser.SystemComponents.Contracts/ISystemInfo.cs
@@ -47,5 +47,10 @@ namespace SafeExamBrowser.SystemComponents.Contracts
 		/// The MAC Addres of the network addapter
 		/// </summary>
 		string MacAddress { get; }
+
+		/// <summary>
+		/// Provides the DeviceID information of the user's Plug and Play devices 
+		/// </summary>
+		string[] DeviceId { get; }
 	}
 }

--- a/SafeExamBrowser.SystemComponents.Contracts/ISystemInfo.cs
+++ b/SafeExamBrowser.SystemComponents.Contracts/ISystemInfo.cs
@@ -42,5 +42,10 @@ namespace SafeExamBrowser.SystemComponents.Contracts
 		/// Provides detailed version information about the currently running operating system.
 		/// </summary>
 		string OperatingSystemInfo { get; }
+
+		/// <summary>
+		/// The MAC Addres of the network addapter
+		/// </summary>
+		string MacAddress { get; }
 	}
 }

--- a/SafeExamBrowser.SystemComponents/SystemInfo.cs
+++ b/SafeExamBrowser.SystemComponents/SystemInfo.cs
@@ -23,6 +23,7 @@ namespace SafeExamBrowser.SystemComponents
 		public string Model { get; private set; }
 		public string Name { get; private set; }
 		public OperatingSystem OperatingSystem { get; private set; }
+		public string MacAddress { get; private set; }
 
 		public string OperatingSystemInfo
 		{
@@ -34,6 +35,7 @@ namespace SafeExamBrowser.SystemComponents
 			InitializeBattery();
 			InitializeMachineInfo();
 			InitializeOperatingSystem();
+			InitializeMacAddress();
 		}
 
 		private void InitializeBattery()
@@ -127,6 +129,31 @@ namespace SafeExamBrowser.SystemComponents
 		private string Architecture()
 		{
 			return Environment.Is64BitOperatingSystem ? "x64" : "x86";
+		}
+		private void InitializeMacAddress()
+		{
+			using (var searcher = new ManagementObjectSearcher("Select MACAddress from Win32_NetworkAdapterConfiguration WHERE DNSDomain IS NOT NULL"))
+			using (var results = searcher.Get())
+			{
+				if (results.Count > 0)
+				{
+					using (var system = results.Cast<ManagementObject>().First())
+					{
+						foreach (var property in system.Properties)
+						{
+
+							if (property.Name.Equals("MACAddress"))
+							{
+								MacAddress = Convert.ToString(property.Value).Replace(":", "").ToUpper();
+							}
+						}
+					}
+				}
+				else
+				{
+					MacAddress = "000000000000";
+				}
+			}
 		}
 	}
 }

--- a/SafeExamBrowser.SystemComponents/SystemInfo.cs
+++ b/SafeExamBrowser.SystemComponents/SystemInfo.cs
@@ -25,7 +25,7 @@ namespace SafeExamBrowser.SystemComponents
 		public string Name { get; private set; }
 		public OperatingSystem OperatingSystem { get; private set; }
 		public string MacAddress { get; private set; }
-		public string[] DeviceId { get; private set; }
+		public string[] PlugAndPlayDeviceIds { get; private set; }
 
 		public string OperatingSystemInfo
 		{
@@ -133,16 +133,18 @@ namespace SafeExamBrowser.SystemComponents
 		{
 			return Environment.Is64BitOperatingSystem ? "x64" : "x86";
 		}
+
 		private void InitializeMacAddress()
 		{
 			using (var searcher = new ManagementObjectSearcher("Select MACAddress from Win32_NetworkAdapterConfiguration WHERE DNSDomain IS NOT NULL"))
 			using (var results = searcher.Get())
 			{
-				if (results.Count > 0)
+				
+				if (results != null && results.Count > 0)
 				{
-					using (var system = results.Cast<ManagementObject>().First())
+					using (var networkAdapter = results.Cast<ManagementObject>().First())
 					{
-						foreach (var property in system.Properties)
+						foreach (var property in networkAdapter.Properties)
 						{
 
 							if (property.Name.Equals("MACAddress"))
@@ -158,25 +160,27 @@ namespace SafeExamBrowser.SystemComponents
 				}
 			}
 		}
+
 		private void InitializePnPDevices()
 		{
-			List<string> deviceList = new List<string>();
+			var deviceList = new List<string>();
 			using (var searcher = new ManagementObjectSearcher("root\\CIMV2", "SELECT DeviceID FROM Win32_PnPEntity"))
 			using (var results = searcher.Get())
 			{
 				foreach (ManagementObject queryObj in results)
 				{
-					using (queryObj)
+					using (queryObj) 
+					{ 
 						foreach (var property in queryObj.Properties)
 						{
 							if (property.Name.Equals("DeviceID"))
 							{
-								Console.WriteLine(Convert.ToString(property.Value));
 								deviceList.Add(Convert.ToString(property.Value).ToLower());
 							}
 						}
+					}
 				}
-				DeviceId = deviceList.ToArray();
+				PlugAndPlayDeviceIds = deviceList.ToArray();
 
 			}
 		}

--- a/SafeExamBrowser.SystemComponents/SystemInfo.cs
+++ b/SafeExamBrowser.SystemComponents/SystemInfo.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Management;
 using System.Windows.Forms;
@@ -24,6 +25,7 @@ namespace SafeExamBrowser.SystemComponents
 		public string Name { get; private set; }
 		public OperatingSystem OperatingSystem { get; private set; }
 		public string MacAddress { get; private set; }
+		public string[] DeviceId { get; private set; }
 
 		public string OperatingSystemInfo
 		{
@@ -36,6 +38,7 @@ namespace SafeExamBrowser.SystemComponents
 			InitializeMachineInfo();
 			InitializeOperatingSystem();
 			InitializeMacAddress();
+			InitializePnPDevices();
 		}
 
 		private void InitializeBattery()
@@ -153,6 +156,28 @@ namespace SafeExamBrowser.SystemComponents
 				{
 					MacAddress = "000000000000";
 				}
+			}
+		}
+		private void InitializePnPDevices()
+		{
+			List<string> deviceList = new List<string>();
+			using (var searcher = new ManagementObjectSearcher("root\\CIMV2", "SELECT DeviceID FROM Win32_PnPEntity"))
+			using (var results = searcher.Get())
+			{
+				foreach (ManagementObject queryObj in results)
+				{
+					using (queryObj)
+						foreach (var property in queryObj.Properties)
+						{
+							if (property.Name.Equals("DeviceID"))
+							{
+								Console.WriteLine(Convert.ToString(property.Value));
+								deviceList.Add(Convert.ToString(property.Value).ToLower());
+							}
+						}
+				}
+				DeviceId = deviceList.ToArray();
+
 			}
 		}
 	}

--- a/SafeExamBrowser.SystemComponents/VirtualMachineDetector.cs
+++ b/SafeExamBrowser.SystemComponents/VirtualMachineDetector.cs
@@ -15,7 +15,7 @@ namespace SafeExamBrowser.SystemComponents
 	{
 		private ILogger logger;
 		private ISystemInfo systemInfo;
-
+		private static readonly string[] pciVendorBlacklist = { "vbox", "80ee", "qemu", "1af4", "1b36" }; //Virtualbox: VBOX, 80EE   RedHat: QUEMU, 1AF4, 1B36
 		public VirtualMachineDetector(ILogger logger, ISystemInfo systemInfo)
 		{
 			this.logger = logger;
@@ -33,6 +33,17 @@ namespace SafeExamBrowser.SystemComponents
 			isVirtualMachine |= manufacturer.Contains("parallels software");
 			isVirtualMachine |= model.Contains("virtualbox");
 			isVirtualMachine |= manufacturer.Contains("qemu");
+			
+			var macAddr = (from nic in NetworkInterface.GetAllNetworkInterfaces() where nic.OperationalStatus == OperationalStatus.Up select nic.GetPhysicalAddress().ToString()).FirstOrDefault();
+			isVirtualMachine |= ((byte.Parse(macAddr[1].ToString(), NumberStyles.HexNumber) & 2) == 2 || macAddr.StartsWith("080027"));
+
+			using (var searcher = new ManagementObjectSearcher("root\\CIMV2", "SELECT DeviceID FROM Win32_PnPEntity"))
+
+				foreach (ManagementObject queryObj in searcher.Get())
+				{
+				isVirtualMachine |= pciVendorBlacklist.Any(System.Convert.ToString(queryObj.Properties.Cast<PropertyData>().First().Value).ToLower().Contains);
+					
+				}
 
 			logger.Debug($"Computer '{systemInfo.Name}' appears to {(isVirtualMachine ? "" : "not ")}be a virtual machine.");
 

--- a/SafeExamBrowser.SystemComponents/VirtualMachineDetector.cs
+++ b/SafeExamBrowser.SystemComponents/VirtualMachineDetector.cs
@@ -32,21 +32,25 @@ namespace SafeExamBrowser.SystemComponents
 			var manufacturer = systemInfo.Manufacturer.ToLower();
 			var model = systemInfo.Model.ToLower();
 			var macAddress = systemInfo.MacAddress;
-			var deviceId = systemInfo.DeviceId;
-			
+			var plugAndPlayDeviceIds = systemInfo.PlugAndPlayDeviceIds;
+
 			isVirtualMachine |= manufacturer.Contains("microsoft corporation") && !model.Contains("surface");
 			isVirtualMachine |= manufacturer.Contains("vmware");
 			isVirtualMachine |= manufacturer.Contains("parallels software");
 			isVirtualMachine |= model.Contains("virtualbox");
 			isVirtualMachine |= manufacturer.Contains("qemu");
-			
-			isVirtualMachine |= ((byte.Parse(macAddress[1].ToString(), NumberStyles.HexNumber) & 2) == 2 || macAddress.StartsWith("080027"));
-			
-			foreach (var device in deviceId)
+
+			if (macAddress != null && macAddress.Count() > 2)
+			{
+				isVirtualMachine |= ((byte.Parse(macAddress[1].ToString(), NumberStyles.HexNumber) & 2) == 2 || macAddress.StartsWith("080027"));
+			}
+
+			foreach (var device in plugAndPlayDeviceIds)
 			{
 				isVirtualMachine |= PCI_VENDOR_BLACKLIST.Any(device.ToLower().Contains);
 
 			}
+
 			logger.Debug($"Computer '{systemInfo.Name}' appears to {(isVirtualMachine ? "" : "not ")}be a virtual machine.");
 
 			return isVirtualMachine;

--- a/SafeExamBrowser.SystemComponents/VirtualMachineDetector.cs
+++ b/SafeExamBrowser.SystemComponents/VirtualMachineDetector.cs
@@ -8,6 +8,10 @@
 
 using SafeExamBrowser.Logging.Contracts;
 using SafeExamBrowser.SystemComponents.Contracts;
+using System.Globalization;
+using System.Linq;
+using System.Management;
+using System.Net.NetworkInformation;s;
 
 namespace SafeExamBrowser.SystemComponents
 {

--- a/SafeExamBrowser.SystemComponents/VirtualMachineDetector.cs
+++ b/SafeExamBrowser.SystemComponents/VirtualMachineDetector.cs
@@ -11,7 +11,7 @@ using SafeExamBrowser.SystemComponents.Contracts;
 using System.Globalization;
 using System.Linq;
 using System.Management;
-using System.Net.NetworkInformation;s;
+using System.Net.NetworkInformation;
 
 namespace SafeExamBrowser.SystemComponents
 {

--- a/SafeExamBrowser.SystemComponents/VirtualMachineDetector.cs
+++ b/SafeExamBrowser.SystemComponents/VirtualMachineDetector.cs
@@ -9,7 +9,7 @@
 using SafeExamBrowser.Logging.Contracts;
 using SafeExamBrowser.SystemComponents.Contracts;
 using System.Globalization;
-
+using System.Linq;
 
 namespace SafeExamBrowser.SystemComponents
 {
@@ -32,7 +32,8 @@ namespace SafeExamBrowser.SystemComponents
 			var manufacturer = systemInfo.Manufacturer.ToLower();
 			var model = systemInfo.Model.ToLower();
 			var macAddress = systemInfo.MacAddress;
-
+			var deviceId = systemInfo.DeviceId;
+			
 			isVirtualMachine |= manufacturer.Contains("microsoft corporation") && !model.Contains("surface");
 			isVirtualMachine |= manufacturer.Contains("vmware");
 			isVirtualMachine |= manufacturer.Contains("parallels software");
@@ -40,15 +41,12 @@ namespace SafeExamBrowser.SystemComponents
 			isVirtualMachine |= manufacturer.Contains("qemu");
 			
 			isVirtualMachine |= ((byte.Parse(macAddress[1].ToString(), NumberStyles.HexNumber) & 2) == 2 || macAddress.StartsWith("080027"));
-			/*
-			using (var searcher = new ManagementObjectSearcher("root\\CIMV2", "SELECT DeviceID FROM Win32_PnPEntity"))
+			
+			foreach (var device in deviceId)
+			{
+				isVirtualMachine |= PCI_VENDOR_BLACKLIST.Any(device.ToLower().Contains);
 
-				foreach (ManagementObject queryObj in searcher.Get())
-				{
-				isVirtualMachine |= pciVendorBlacklist.Any(System.Convert.ToString(queryObj.Properties.Cast<PropertyData>().First().Value).ToLower().Contains);
-					
-				}
-				*/
+			}
 			logger.Debug($"Computer '{systemInfo.Name}' appears to {(isVirtualMachine ? "" : "not ")}be a virtual machine.");
 
 			return isVirtualMachine;


### PR DESCRIPTION
In the case of Virtualbox and Quemu this detection may not be enough because they let change the system information.
I have implemented 2 new ways of detection, virtual MAC and pci vendor search

Virtualized MAC:
The seventh bit of the first byte is the universal/local bit. A locally assigned mac will have this bit set to 1, while one assigned by a company will have it set to 0. [https://tools.ietf.org/html/rfc4291#section-2.5.1](https://tools.ietf.org/html/rfc4291#section-2.5.1)

PCI Vendor:
A complicated element to change is the vendor of a component, I have created a list with the virtualbox and Redhat(quemu) vendors and I look for traces of them in the Plug and Play devices

