### PR TITLE
Issue 747 fix

### DIFF
--- a/SafeExamBrowser.Runtime/Operations/SessionIntegrityOperation.cs
+++ b/SafeExamBrowser.Runtime/Operations/SessionIntegrityOperation.cs
@@ -77,7 +77,7 @@ namespace SafeExamBrowser.Runtime.Operations
 				foreach (var cursor in cursors.Where(c => !string.IsNullOrWhiteSpace(c)))
 				{
 					success &= registry.TryRead(RegistryValue.UserHive.Cursors_Key, cursor, out var value);
-					success &= value == default || !(value is string) || (value is string path && (string.IsNullOrWhiteSpace(path) || IsValidCursorPath(path)));
+					success &= !(value is string) || (value is string path && (string.IsNullOrWhiteSpace(path) || IsValidCursorPath(path)));
 
 					if (!success)
 					{

--- a/SafeExamBrowser.Runtime/Operations/SessionIntegrityOperation.cs
+++ b/SafeExamBrowser.Runtime/Operations/SessionIntegrityOperation.cs
@@ -113,7 +113,7 @@ namespace SafeExamBrowser.Runtime.Operations
 
 			if (registry.TryRead(RegistryValue.MachineHive.EaseOfAccess_Key, RegistryValue.MachineHive.EaseOfAccess_Name, out var value))
 			{
-				if (value == default || (value is string s && string.IsNullOrWhiteSpace(s)))
+				if (value is string s && string.IsNullOrWhiteSpace(s))
 				{
 					success = true;
 					logger.Info("Ease of access configuration successfully verified.");
@@ -135,7 +135,8 @@ namespace SafeExamBrowser.Runtime.Operations
 			}
 			else
 			{
-				logger.Error("Failed to verify ease of access configuration!");
+				success = true;
+				logger.Info("Ease of access configuration successfully verified (value does not exist).");
 			}
 
 			return success;

--- a/SafeExamBrowser.SystemComponents/Registry/Registry.cs
+++ b/SafeExamBrowser.SystemComponents/Registry/Registry.cs
@@ -86,7 +86,7 @@ namespace SafeExamBrowser.SystemComponents.Registry
 				logger.Error($"Failed to read value '{name}' from registry key '{key}'!", e);
 			}
 
-			return value != default && value != defaultValue;
+			return value != default && !ReferenceEquals(value, defaultValue);
 		}
 
 		public bool TryGetNames(string keyName, out IEnumerable<string> names)

--- a/SafeExamBrowser.SystemComponents/Registry/Registry.cs
+++ b/SafeExamBrowser.SystemComponents/Registry/Registry.cs
@@ -73,21 +73,20 @@ namespace SafeExamBrowser.SystemComponents.Registry
 
 		public bool TryRead(string key, string name, out object value)
 		{
-			var success = false;
-
+			var defaultValue = new object();
+			
 			value = default;
 
 			try
 			{
-				value = Microsoft.Win32.Registry.GetValue(key, name, default);
-				success = true;
+				value = Microsoft.Win32.Registry.GetValue(key, name, defaultValue);
 			}
 			catch (Exception e)
 			{
 				logger.Error($"Failed to read value '{name}' from registry key '{key}'!", e);
 			}
 
-			return success;
+			return value != default && value != defaultValue;
 		}
 
 		public bool TryGetNames(string keyName, out IEnumerable<string> names)


### PR DESCRIPTION
`registry.TryRead()` shall now return `false` when a registry **value** does not exist inside of a key. Previously this returned `true` and made the caller check if `output_var != default` to check if the value actually existed. This is a fix for #747 .

I have converted existing direct calls to TryRead() as you can see in the code. I have tested this and it seems like it works correctly. Additionally, I have tested the original bug by creating `HKEY_LOCAL_MACHINE\SYSTEM\HardwareConfig\sebcrash` without any values in it. In the old version, this caused a crash because the code didn't check if the value actually existed, and hence caused a nullptr deref exception. In the new version, the code checks if the registry value does not exist, and if so it does not continue with inspecting the value in the caller code. 

One possible issue I have seen is that the `StartMonitoring()` and `Timer_Elapsed()` functions will now error if a value does not exist. Hence, we will need to think of a solution to monitor for registry value creations, since we cannot monitor for non-existing values in the current state. 