### PR TITLE
Added blocking of windows programs & browsers which allows to cheat.

### DIFF
--- a/SafeExamBrowser.Configuration/ConfigurationData/DataValues.cs
+++ b/SafeExamBrowser.Configuration/ConfigurationData/DataValues.cs
@@ -109,6 +109,9 @@ namespace SafeExamBrowser.Configuration.ConfigurationData
 			settings.Applications.Blacklist.Add(new BlacklistApplication { ExecutableName = "Camtasia_Studio.exe", OriginalName = "Camtasia_Studio.exe" });
 			settings.Applications.Blacklist.Add(new BlacklistApplication { ExecutableName = "CamRecorder.exe", OriginalName = "CamRecorder.exe" });
 			settings.Applications.Blacklist.Add(new BlacklistApplication { ExecutableName = "CamtasiaUtl.exe", OriginalName = "CamtasiaUtl.exe" });
+			settings.Applications.Blacklist.Add(new BlacklistApplication { ExecutableName = "chrome.exe", OriginalName = "chrome.exe" });
+			settings.Applications.Blacklist.Add(new BlacklistApplication { ExecutableName = "msedge.exe", OriginalName = "msedge.exe" });
+			settings.Applications.Blacklist.Add(new BlacklistApplication { ExecutableName = "notepad.exe", OriginalName = "notepad.exe" });
 			settings.Applications.Blacklist.Add(new BlacklistApplication { ExecutableName = "chromoting.exe", OriginalName = "chromoting.exe" });
 			settings.Applications.Blacklist.Add(new BlacklistApplication { ExecutableName = "CiscoCollabHost.exe", OriginalName = "CiscoCollabHost.exe" });
 			settings.Applications.Blacklist.Add(new BlacklistApplication { ExecutableName = "CiscoWebExStart.exe", OriginalName = "CiscoWebExStart.exe" });


### PR DESCRIPTION
**Hello Team,**

**I have added a block check for chrome & ms-edge browser as they allow to cheat in exams for students as file path traversal is also possible through browser which is initially blocked on your safeexambrowser software.**

- **You can select Ethier on browser if it is causing some problem or seems trivial, make sure to check a block for file path traversal in the browser which would allow students to visit files and folders on system which are initially restricted.**

**I have also added notepad to get blocked so students cannot copy the questions and paste it anywhere, this would stop them to copy questions and would force to write questions in they did try to cheat (such long work will automatically be avoided by the students and hence will drop the idea of writing questions itself for copy-pasting purposes and time constraint)**