### PR TITLE
Blocking injtected keyboard inputs.

### DIFF
--- a/SafeExamBrowser.Monitoring/Keyboard/KeyboardInterceptor.cs
+++ b/SafeExamBrowser.Monitoring/Keyboard/KeyboardInterceptor.cs
@@ -77,6 +77,8 @@ namespace SafeExamBrowser.Monitoring.Keyboard
 			block |= modifier.HasFlag(KeyModifier.Ctrl) && key == Key.V && !settings.AllowCtrlV;
 			block |= modifier.HasFlag(KeyModifier.Ctrl) && key == Key.X && !settings.AllowCtrlX;
 
+			block |= modifier.HasFlag(KeyModifier.Injected);
+
 			if (block)
 			{
 				Log(key, keyCode, modifier, state);

--- a/SafeExamBrowser.WindowsApi.Contracts/Events/KeyModifier.cs
+++ b/SafeExamBrowser.WindowsApi.Contracts/Events/KeyModifier.cs
@@ -18,6 +18,7 @@ namespace SafeExamBrowser.WindowsApi.Contracts.Events
 	{
 		None = 0,
 		Alt = 0b1,
-		Ctrl = 0b10
+		Ctrl = 0b10,
+		Injected = 0b100
 	}
 }

--- a/SafeExamBrowser.WindowsApi/Hooks/KeyboardHook.cs
+++ b/SafeExamBrowser.WindowsApi/Hooks/KeyboardHook.cs
@@ -96,6 +96,11 @@ namespace SafeExamBrowser.WindowsApi.Hooks
 				modifier |= KeyModifier.Ctrl;
 			}
 
+			if(keyData.Flags.HasFlag(KBDLLHOOKSTRUCTFlags.LLKHF_INJECTED) || keyData.Flags.HasFlag(KBDLLHOOKSTRUCTFlags.LLKHF_LOWER_IL_INJECTED))
+			{
+				modifier |= KeyModifier.Injected;
+			}
+
 			return modifier;
 		}
 

--- a/SafeExamBrowser.WindowsApi/Types/KBDLLHOOKSTRUCTFlags.cs
+++ b/SafeExamBrowser.WindowsApi/Types/KBDLLHOOKSTRUCTFlags.cs
@@ -19,6 +19,11 @@ namespace SafeExamBrowser.WindowsApi.Types
 		LLKHF_EXTENDED = 0x01,
 
 		/// <summary>
+		/// Test the event-injected (from a process running at lower integrity leve) flag. 
+		/// </summary>
+		LLKHF_LOWER_IL_INJECTED = 0x02,
+
+		/// <summary>
 		/// Test the event-injected (from any process) flag.
 		/// </summary>
 		LLKHF_INJECTED = 0x10,


### PR DESCRIPTION
A common tactic to emulate keyboard presses is via win32api functions like keybd_event, SendInput, NtUserInjectKeyboardInput.
All these have the injected flag set.

/ Oliver