### PR TITLE
Ignoring SessionLock/Unlock (suspend and/or lock/unlock) to prevent false redscreens

### DIFF
--- a/SafeExamBrowser.Client/Responsibilities/MonitoringResponsibility.cs
+++ b/SafeExamBrowser.Client/Responsibilities/MonitoringResponsibility.cs
@@ -263,13 +263,13 @@ namespace SafeExamBrowser.Client.Responsibilities
 			{
 				Logger.Info($"Detected user session change, but {(allow ? "session locking and/or switching is allowed" : "lock screen is deactivated")}.");
 			}
-			else if (isSessionLockEvent || isSessionUnlockEvent)
+			else if (Settings.Service.IgnoreService && (isSessionLockEvent || isSessionUnlockEvent))
 			{
 				Logger.Info($"Detected user session {(isSessionLockEvent ? "lock" : "unlock")}, ignoring!");
 			}
 			else
 			{
-				var message = text.Get(TextKey.LockScreen_UserSessionMessage);
+				var message = text.Get(Settings.Service.IgnoreService ? TextKey.LockScreen_UserSwitchMessage : TextKey.LockScreen_UserSessionMessage);
 				var title = text.Get(TextKey.LockScreen_Title);
 				var continueOption = new LockScreenOption { Text = text.Get(TextKey.LockScreen_UserSessionContinueOption) };
 				var terminateOption = new LockScreenOption { Text = text.Get(TextKey.LockScreen_UserSessionTerminateOption) };

--- a/SafeExamBrowser.Client/Responsibilities/MonitoringResponsibility.cs
+++ b/SafeExamBrowser.Client/Responsibilities/MonitoringResponsibility.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Win32;
 using SafeExamBrowser.Client.Contracts;
 using SafeExamBrowser.I18n.Contracts;
 using SafeExamBrowser.Logging.Contracts;
@@ -251,14 +252,20 @@ namespace SafeExamBrowser.Client.Responsibilities
 			}
 		}
 
-		private void Sentinel_SessionChanged()
+		private void Sentinel_SessionChanged(SessionSwitchReason reason)
 		{
+			
 			var allow = !Settings.Service.IgnoreService && (!Settings.Service.DisableUserLock || !Settings.Service.DisableUserSwitch);
 			var disable = Settings.Security.DisableSessionChangeLockScreen;
-
+			var isSessionLockEvent = reason == SessionSwitchReason.SessionLock;
+			var isSessionUnlockEvent = reason == SessionSwitchReason.SessionUnlock;
 			if (allow || disable)
 			{
 				Logger.Info($"Detected user session change, but {(allow ? "session locking and/or switching is allowed" : "lock screen is deactivated")}.");
+			}
+			else if (isSessionLockEvent || isSessionUnlockEvent)
+			{
+				Logger.Info($"Detected user session {(isSessionLockEvent ? "lock" : "unlock")}, ignoring!");
 			}
 			else
 			{

--- a/SafeExamBrowser.I18n.Contracts/TextKey.cs
+++ b/SafeExamBrowser.I18n.Contracts/TextKey.cs
@@ -90,6 +90,7 @@ namespace SafeExamBrowser.I18n.Contracts
 		LockScreen_UnlockButton,
 		LockScreen_UserSessionContinueOption,
 		LockScreen_UserSessionMessage,
+		LockScreen_UserSwitchMessage,
 		LockScreen_UserSessionTerminateOption,
 		LogWindow_AlwaysOnTop,
 		LogWindow_AutoScroll,

--- a/SafeExamBrowser.I18n/Data/de.xml
+++ b/SafeExamBrowser.I18n/Data/de.xml
@@ -228,6 +228,9 @@
     <Entry key="LockScreen_UserSessionMessage">
         Der aktive Benutzer hat sich geändert oder der Computer wurde gesperrt! Bitte wählen Sie eine der verfügbaren Optionen aus und geben Sie das korrekte Passwort ein, um SEB zu entsperren.
     </Entry>
+    <Entry key="LockScreen_UserSwitchMessage">
+        Der aktive Benutzer hat sich geändert! Bitte wählen Sie eine der verfügbaren Optionen aus und geben Sie das korrekte Passwort ein, um SEB zu entsperren.
+    </Entry>
     <Entry key="LockScreen_UserSessionTerminateOption">
         Safe Exam Browser beenden. WARNUNG: Sie werden keine Möglichkeit haben, Daten zu speichern oder weitere Aktionen auszuführen, SEB wird sofort beendet!
     </Entry>

--- a/SafeExamBrowser.I18n/Data/en.xml
+++ b/SafeExamBrowser.I18n/Data/en.xml
@@ -228,6 +228,9 @@
     <Entry key="LockScreen_UserSessionMessage">
         The active user has changed or the computer has been locked! In order to unlock SEB, please select one of the available options and enter the correct unlock password.
     </Entry>
+    <Entry key="LockScreen_UserSwitchMessage">
+        The active user has changed. In order to unlock SEB, please select one of the available options and enter the correct unlock password.
+    </Entry>
     <Entry key="LockScreen_UserSessionTerminateOption">
         Terminate Safe Exam Browser. WARNING: There will be no possibility to save data or perform any further actions, the shutdown will be initiated immediately!
     </Entry>

--- a/SafeExamBrowser.Monitoring.Contracts/System/Events/SessionChangedEventHandler.cs
+++ b/SafeExamBrowser.Monitoring.Contracts/System/Events/SessionChangedEventHandler.cs
@@ -6,10 +6,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+using Microsoft.Win32;
+
 namespace SafeExamBrowser.Monitoring.Contracts.System.Events
 {
 	/// <summary>
 	/// Indicates that the active user session of the operating system has changed.
 	/// </summary>
-	public delegate void SessionChangedEventHandler();
+	public delegate void SessionChangedEventHandler(SessionSwitchReason reason);
 }

--- a/SafeExamBrowser.Monitoring/System/Components/SystemEvents.cs
+++ b/SafeExamBrowser.Monitoring/System/Components/SystemEvents.cs
@@ -81,7 +81,7 @@ namespace SafeExamBrowser.Monitoring.System.Components
 		private void SystemEvents_SessionChanged(object sender, SessionSwitchEventArgs e)
 		{
 			logger.Info($"User session change detected: {e.Reason}.");
-			Task.Run(() => SessionChanged?.Invoke());
+			Task.Run(() => SessionChanged?.Invoke(e.Reason));
 		}
 
 		private void SystemEvents_TimeChanged(object sender, EventArgs e)

--- a/SafeExamBrowser.Monitoring/System/SystemSentinel.cs
+++ b/SafeExamBrowser.Monitoring/System/SystemSentinel.cs
@@ -70,7 +70,7 @@ namespace SafeExamBrowser.Monitoring.System
 
 		public void StartMonitoringSystemEvents()
 		{
-			systemEvents.SessionChanged += () => SessionChanged?.Invoke();
+			systemEvents.SessionChanged += (reason) => SessionChanged?.Invoke(reason);
 			systemEvents.StartMonitoring();
 		}
 


### PR DESCRIPTION
Students currently do not have the ability to close/suspend their laptops during (longer) exams because then a redscreen is shown. Furthermore, the shown redscreen message confuses invigilators as it does not allow to differenciate between cheating (user switch) and suspend/lock.

Luckily, the windows api sends different events depending on the action taken. As shown below, the SessionLock/SessionUnlock event can be filtered out as a user switch also produces a ConsoleDisconnect/ConsoleConnect event in addtion to the SessionLock/SessionUnlock event. 

**lock/unlock**
Session locked
Session unlocked

**user switch**
Console disconnected
Session locked
Console connected
Session unlocked

The exact SessionSwitch event is currently already logged but not propagated to the MonitoringResponsibility class.

With this PR SessionLock/SessionUnlock is only filtered out when ignoring SEB service as UserSwitch and UserLock can be enabled/disabled when using SEB service.

Furthermore, we've introduced a new lockscreen message in case the event is a UserSwitch as the existing message is still used when using SEB service. We've added a german and an english translation. If our PR is acceptable it should be easy to copy and modify the other translations.