### PR TITLE
Fix pasted/cut content vanishing in framework-driven inputs (isolated clipboard) by dispatching a synthetic input event

### DIFF
--- a/SafeExamBrowser.Browser/Content/Clipboard.js
+++ b/SafeExamBrowser.Browser/Content/Clipboard.js
@@ -158,6 +158,15 @@ if (typeof pasteContent === 'undefined') {
 	}
 }
 
+if (typeof notifyInput === 'undefined') {
+	// Programmatic value changes (setRangeText/insertNode) emit no input event; notify frameworks explicitly.
+	function notifyInput(target, inputType) {
+		if (target && typeof target.dispatchEvent === 'function') {
+			target.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: inputType }));
+		}
+	}
+}
+
 if (typeof onCopy === 'undefined') {
 	function onCopy(e) {
 		try {
@@ -185,6 +194,8 @@ if (typeof onCut === 'undefined') {
 			cutSelection(e);
 
 			CefSharp.PostMessage({ Type: "Clipboard", Id: SafeExamBrowser.clipboard.id, Content: SafeExamBrowser.clipboard.getContentEncoded() });
+
+			notifyInput(e.target, "deleteByCut");
 		} finally {
 			e.preventDefault();
 		}
@@ -200,6 +211,8 @@ if (typeof onPaste === 'undefined') {
 	function onPaste(e) {
 		try {
 			pasteContent(e);
+
+			notifyInput(e.target, "insertFromPaste");
 		} finally {
 			e.preventDefault();
 		}


### PR DESCRIPTION
### Summary

When the clipboard policy is set to **“SEB Only” (isolated)**, content pasted into an `<input>` / `<textarea>` (or a `contenteditable`) is not reflected in JavaScript frameworks that track a field's value via the `input` event (React, Vue, Angular, …). The pasted text is visible at first, but disappears again as soon as the field loses focus (blur) — unless the user additionally types at least one character.

### Root cause

The isolated clipboard is implemented in `SafeExamBrowser.Browser/Content/Clipboard.js`. Its handlers mutate the field directly and suppress the native clipboard action:

- `pasteContent()` inserts the text via `HTMLTextAreaElement.setRangeText()` / `HTMLInputElement.setRangeText()` for inputs and text areas, and via `Range.insertNode()` / `Range.deleteContents()` for `contenteditable` / `designMode`.
- `cutSelection()` removes the selection via `setRangeText("")` / `deleteContents()`.
- `onPaste()` / `onCut()` then call `e.preventDefault()`.

None of `setRangeText()`, `insertNode()` or `deleteContents()` emit an `input` event, and because the native paste/cut is cancelled via `preventDefault()`, the native `input` event (`inputType: "insertFromPaste"` / `"deleteByCut"`) never fires either. As a result, frameworks that derive their internal value from the `input` event never observe the change. On the next render — e.g. when the field blurs — they reset the DOM value back to their (empty) internal state, and the pasted text is lost. Typing a character produces a real `input` event, which is why adding input “fixes” it for the user.

### Fix

`onPaste()` and `onCut()` now dispatch a synthetic, bubbling `InputEvent` on the event target after mutating the field:

```js
function notifyInput(target, inputType) {
    if (target && typeof target.dispatchEvent === 'function') {
        target.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: inputType }));
    }
}
```

- `onPaste` → `notifyInput(e.target, "insertFromPaste")`
- `onCut` → `notifyInput(e.target, "deleteByCut")`

This mirrors what the native paste/cut would have emitted (`beforeinput`/`input` with the respective `inputType`) and keeps framework-controlled inputs in sync. Because `setRangeText()` / `insertNode()` have already updated the real DOM value before the event is dispatched, frameworks (e.g. React, which compares the DOM value against its value tracker) pick up the correct, complete value.

`onCopy` is intentionally left unchanged — copying does not modify the field.

### Reproduction

- **Test-Page:** https://uploads.whatwedo.io/seb/clipboard-reproduction/index.html
- **SEB-Config (w/o Exit PW):** sebs://uploads.whatwedo.io/seb/clipboard-reproduction/seb-reprod-clipboard.seb

Copy the sample text on the page (`Ctrl+C`), paste it into the text area (`Ctrl+V`), then click outside the field. On the affected build the event log shows `paste` **without** a following `input`, and the text vanishes on blur. With this fix the log shows `paste → input`, and the text is retained.
